### PR TITLE
Docs: fix duplicated Example 2 screenshot and streamline README customization guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,35 @@ Merchant Server - Payu Server means that call is made from merchant server to Pa
 * `Merchant Backend` send `OrderCreateRequest` with user details, products details and payment method details and return the result of `OrderCreateResponse` to `Merchant Mobile App` (see how to make `OrderCreateRequest` [here](https://developers.payu.com/en/restapi.html#creating_new_order)
 * `Merchant Mobile App` handle the result of `OrderCreateResponse` (see how to handle the result of `OrderCreateResponse` [here](payu_web_payments/)
 
+<a id="ui_customization"></a>
+
+## UI Customization
+
+The PayU Flutter plugin exposes a single `Payu.theme` property that accepts a standard Material `ThemeData` object. Every PayU screen and widget is wrapped internally by a `Theme` widget that injects `Payu.theme`, so all visual changes flow through one place:
+
+```dart
+void main() {
+  Payu.theme = ThemeData(
+    colorScheme: ColorScheme.light(
+      primary: Colors.indigo,
+    ),
+  );
+
+  runApp(const MyApp());
+}
+```
+
+Key customization points:
+
+* **Colors** — set via `colorScheme` (`primary`, `secondary`, `surface`, `onSurface`, …)
+* **Typography** — override `textTheme` or set a custom `fontFamily`
+* **Cards & inputs** — `cardTheme` and `inputDecorationTheme` control the look of payment cards and text fields
+* **Buttons** — `elevatedButtonTheme` changes the primary action button style
+* **Shape / elevation** — adjust `cardTheme.shape` and `cardTheme.elevation` for rounded or flat cards
+* **Dark / light mode** — set `Payu.theme = null` to restore the default theme which automatically follows device brightness
+
+For full details, advanced recipes, and real-world styling examples see the [Theme Customization guide](payu_ui/THEME_CUSTOMIZATION.md).
+
 ## Additional information
 
 TODO: Tell users more about the package: where to find more information, how to 

--- a/README.md
+++ b/README.md
@@ -84,30 +84,9 @@ Merchant Server - Payu Server means that call is made from merchant server to Pa
 
 ## UI Customization
 
-The PayU Flutter plugin exposes a single `Payu.theme` property that accepts a standard Material `ThemeData` object. Every PayU screen and widget is wrapped internally by a `Theme` widget that injects `Payu.theme`, so all visual changes flow through one place:
+Customize PayU UI with `Payu.theme` (`ThemeData`) to control colors, typography, inputs, cards, and buttons across all PayU screens.
 
-```dart
-void main() {
-  Payu.theme = ThemeData(
-    colorScheme: ColorScheme.light(
-      primary: Colors.indigo,
-    ),
-  );
-
-  runApp(const MyApp());
-}
-```
-
-Key customization points:
-
-* **Colors** — set via `colorScheme` (`primary`, `secondary`, `surface`, `onSurface`, …)
-* **Typography** — override `textTheme` or set a custom `fontFamily`
-* **Cards & inputs** — `cardTheme` and `inputDecorationTheme` control the look of payment cards and text fields
-* **Buttons** — `elevatedButtonTheme` changes the primary action button style
-* **Shape / elevation** — adjust `cardTheme.shape` and `cardTheme.elevation` for rounded or flat cards
-* **Dark / light mode** — set `Payu.theme = null` to restore the default theme which automatically follows device brightness
-
-For full details, advanced recipes, and real-world styling examples see the [Theme Customization guide](payu_ui/THEME_CUSTOMIZATION.md).
+For full details and examples, see the [Theme Customization guide](payu_ui/THEME_CUSTOMIZATION.md).
 
 ## Additional information
 

--- a/payu_ui/README.md
+++ b/payu_ui/README.md
@@ -20,6 +20,4 @@ void main() async {
 
 ## Additional information
 
-TODO: Tell users more about the package: where to find more information, how to 
-contribute to the package, how to file issues, what response they can expect 
-from the package authors, and more.
+- Theme customization guide: [THEME_CUSTOMIZATION.md](./THEME_CUSTOMIZATION.md)

--- a/payu_ui/THEME_CUSTOMIZATION.md
+++ b/payu_ui/THEME_CUSTOMIZATION.md
@@ -15,14 +15,14 @@ void main() {
 ```
 
 - `Payu.theme` is applied inside PayU wrappers:
-  - `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_state_management/lib/src/payu_widget.dart`
-  - `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_ui/lib/src/widgets/payu_provider_widget.dart`
+  - `payu_state_management/lib/src/payu_widget.dart`
+  - `payu_ui/lib/src/widgets/payu_provider_widget.dart`
 - Setting `Payu.theme = null` restores the default PayU theme (`ThemeDataFactory.platform()`).
 
 ## Default PayU theme definition
 
 The default theme is created in:
-- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_ui/lib/src/theme/theme_data_factory.dart`
+- `payu_ui/lib/src/theme/theme_data_factory.dart`
 
 It defines:
 - `appBarTheme`
@@ -37,42 +37,42 @@ It defines:
 
 ### `appBarTheme`
 Used by pages with `AppBar(...)`:
-- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_add_card/lib/src/page/add_card_page.dart`
-- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_payment_methods/lib/src/features/payment_methods/payment_methods_page.dart`
-- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_payment_methods/lib/src/features/pbl_payment_methods/pbl_payment_methods_page.dart`
-- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_web_payments/lib/src/web_payments_page.dart`
+- `payu_add_card/lib/src/page/add_card_page.dart`
+- `payu_payment_methods/lib/src/features/payment_methods/payment_methods_page.dart`
+- `payu_payment_methods/lib/src/features/pbl_payment_methods/pbl_payment_methods_page.dart`
+- `payu_web_payments/lib/src/web_payments_page.dart`
 
 ### `cardTheme`
 Used by `Card(...)` components:
-- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_payment_methods/lib/src/features/payment_methods/payment_methods_page.dart`
-- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_payment_methods/lib/src/features/pbl_payment_methods/pbl_payment_methods_page.dart`
+- `payu_payment_methods/lib/src/features/payment_methods/payment_methods_page.dart`
+- `payu_payment_methods/lib/src/features/pbl_payment_methods/pbl_payment_methods_page.dart`
 
 ### `dialogTheme`
 Used by `AlertDialog(...)` components:
-- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_web_payments/lib/src/cvv/cvv_authorization_alert_dialog.dart`
-- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_three_ds/lib/src/soft_accept/soft_accept_alert_dialog.dart`
-- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_web_payments/lib/src/web_payments_page.dart` (dialogs opened in `showBackAlertDialog` and `showWebResourceErrorAlertDialog`)
+- `payu_web_payments/lib/src/cvv/cvv_authorization_alert_dialog.dart`
+- `payu_three_ds/lib/src/soft_accept/soft_accept_alert_dialog.dart`
+- `payu_web_payments/lib/src/web_payments_page.dart` (dialogs opened in `showBackAlertDialog` and `showWebResourceErrorAlertDialog`)
 
 ### `inputDecorationTheme`
 Used by `TextField(..., decoration: InputDecoration(...))`:
-- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_add_card/lib/src/widget/widgets/add_card_text_field.dart`
-- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_payment_methods/lib/src/features/widget/payment_widget.dart` (`_BlikCode`)
-- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_web_payments/lib/src/cvv/cvv_authorization_alert_dialog.dart`
+- `payu_add_card/lib/src/widget/widgets/add_card_text_field.dart`
+- `payu_payment_methods/lib/src/features/widget/payment_widget.dart` (`_BlikCode`)
+- `payu_web_payments/lib/src/cvv/cvv_authorization_alert_dialog.dart`
 
 ### `textTheme`
 Used with `Theme.of(context).textTheme...`:
-- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_add_card/lib/src/widget/add_card_widget.dart`
-- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_payment_methods/lib/src/features/widget/payment_widget.dart`
-- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_terms_and_conditions/lib/src/terms_and_conditions_widget.dart`
+- `payu_add_card/lib/src/widget/add_card_widget.dart`
+- `payu_payment_methods/lib/src/features/widget/payment_widget.dart`
+- `payu_terms_and_conditions/lib/src/terms_and_conditions_widget.dart`
 
 ### `colorScheme` and `primaryColor`
 Used for surface/background and accent colors:
-- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_add_card/lib/src/page/add_card_page.dart`
-- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_payment_methods/lib/src/features/widget/payment_widget.dart`
-- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_payment_methods/lib/src/features/payment_methods/payment_methods_page.dart`
-- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_payment_methods/lib/src/features/pbl_payment_methods/pbl_payment_methods_page.dart`
-- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_terms_and_conditions/lib/src/terms_and_conditions_widget.dart`
-- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_web_payments/lib/src/web_payments_page.dart`
+- `payu_add_card/lib/src/page/add_card_page.dart`
+- `payu_payment_methods/lib/src/features/widget/payment_widget.dart`
+- `payu_payment_methods/lib/src/features/payment_methods/payment_methods_page.dart`
+- `payu_payment_methods/lib/src/features/pbl_payment_methods/pbl_payment_methods_page.dart`
+- `payu_terms_and_conditions/lib/src/terms_and_conditions_widget.dart`
+- `payu_web_payments/lib/src/web_payments_page.dart`
 
 ## Recommended customization approach
 
@@ -99,4 +99,6 @@ Payu.theme = Payu.theme.copyWith(
 - `TextTheme`: https://api.flutter.dev/flutter/material/TextTheme-class.html
 - `AppBarTheme`: https://api.flutter.dev/flutter/material/AppBarTheme-class.html
 - `DialogThemeData`: https://api.flutter.dev/flutter/material/DialogThemeData-class.html
+
+Input filtering (used by PayU text fields together with themed `InputDecoration`):
 - `FilteringTextInputFormatter`: https://api.flutter.dev/flutter/services/FilteringTextInputFormatter-class.html

--- a/payu_ui/THEME_CUSTOMIZATION.md
+++ b/payu_ui/THEME_CUSTOMIZATION.md
@@ -184,6 +184,188 @@ The remaining slots (`titleLarge`, `titleMedium`, `bodyLarge`, `labelLarge`, `la
 
 ---
 
+## Customization examples
+
+The examples below show two completely different looks to illustrate how far the PayU UI can be tailored to your brand. Set `Payu.theme` before calling `runApp`.
+
+---
+
+### Example 1 — Bold dark / neon
+
+A dark background with vibrant cyan and hot-pink accents, heavy elevation, and large rounded corners.
+
+<!-- TODO: add screenshot -->
+<!-- ![Bold dark / neon theme](docs/screenshots/theme_dark_neon.png) -->
+
+```dart
+void main() {
+  Payu.theme = ThemeData(
+    brightness: Brightness.dark,
+    colorScheme: const ColorScheme.dark(
+      primary: Color(0xFFFF2E63),
+      secondary: Color(0xFF08D9D6),
+      surface: Color(0xFF1A1A2E),
+      onSurface: Colors.white,
+      error: Color(0xFFFF6B6B),
+    ),
+    scaffoldBackgroundColor: const Color(0xFF0F0F1A),
+    appBarTheme: const AppBarTheme(
+      backgroundColor: Color(0xFF1A1A2E),
+      foregroundColor: Color(0xFFFF2E63),
+      centerTitle: true,
+      elevation: 0,
+    ),
+    cardTheme: CardThemeData(
+      color: const Color(0xFF22223B),
+      elevation: 6,
+      shadowColor: Colors.black54,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(20),
+        side: const BorderSide(color: Color(0xFF08D9D6), width: 1.5),
+      ),
+    ),
+    inputDecorationTheme: InputDecorationTheme(
+      filled: true,
+      fillColor: const Color(0xFF2A2A40),
+      hintStyle: const TextStyle(color: Colors.white70),
+      labelStyle: const TextStyle(color: Color(0xFF08D9D6)),
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(16),
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(16),
+        borderSide: const BorderSide(color: Color(0xFF08D9D6)),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(16),
+        borderSide: const BorderSide(color: Color(0xFFFF2E63), width: 2),
+      ),
+    ),
+    textTheme: const TextTheme(
+      bodyMedium: TextStyle(fontSize: 15, color: Colors.white),
+      titleSmall: TextStyle(
+        fontSize: 16,
+        fontWeight: FontWeight.bold,
+        color: Color(0xFFFF2E63),
+      ),
+    ),
+    elevatedButtonTheme: ElevatedButtonThemeData(
+      style: ElevatedButton.styleFrom(
+        backgroundColor: const Color(0xFFFF2E63),
+        foregroundColor: Colors.white,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(14),
+        ),
+      ),
+    ),
+  );
+
+  runApp(const MyApp());
+}
+```
+
+---
+
+### Example 2 — Elegant light / premium
+
+An off-white canvas with warm gold accents and deep navy secondary tones. Subtle borders, generous padding, and no elevation for a refined look.
+
+<!-- TODO: add screenshot -->
+<!-- ![Elegant light / premium theme](docs/screenshots/theme_light_premium.png) -->
+
+```dart
+void main() {
+  Payu.theme = ThemeData(
+    brightness: Brightness.light,
+    scaffoldBackgroundColor: const Color(0xFFFCFBF7),
+    colorScheme: const ColorScheme.light(
+      primary: Color(0xFFB38A3D),
+      secondary: Color(0xFF2F4858),
+      surface: Color(0xFFFFFCF5),
+      onSurface: Color(0xFF2A2A2A),
+      error: Color(0xFFC44536),
+    ),
+    appBarTheme: const AppBarTheme(
+      backgroundColor: Color(0xFFFFFCF5),
+      foregroundColor: Color(0xFFB38A3D),
+      centerTitle: true,
+      elevation: 0,
+    ),
+    cardTheme: CardThemeData(
+      color: Colors.white,
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(24),
+        side: const BorderSide(color: Color(0xFFE7D7B1), width: 1.2),
+      ),
+    ),
+    inputDecorationTheme: InputDecorationTheme(
+      filled: true,
+      fillColor: const Color(0xFFF8F4EA),
+      hintStyle: const TextStyle(color: Color(0xFF8C8577)),
+      labelStyle: const TextStyle(color: Color(0xFFB38A3D)),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 18),
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(18),
+        borderSide: BorderSide.none,
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(18),
+        borderSide: const BorderSide(color: Color(0xFFE7D7B1)),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(18),
+        borderSide: const BorderSide(color: Color(0xFFB38A3D), width: 2),
+      ),
+      errorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(18),
+        borderSide: const BorderSide(color: Color(0xFFC44536)),
+      ),
+    ),
+    textTheme: const TextTheme(
+      titleSmall: TextStyle(
+        fontSize: 16,
+        fontWeight: FontWeight.w600,
+        color: Color(0xFF2F4858),
+      ),
+      bodyMedium: TextStyle(
+        fontSize: 15,
+        height: 1.4,
+        color: Color(0xFF5C5C5C),
+      ),
+      bodySmall: TextStyle(
+        fontSize: 13,
+        color: Color(0xFF8C8577),
+      ),
+    ),
+    elevatedButtonTheme: ElevatedButtonThemeData(
+      style: ElevatedButton.styleFrom(
+        backgroundColor: const Color(0xFFB38A3D),
+        foregroundColor: Colors.white,
+        elevation: 0,
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+      ),
+    ),
+    outlinedButtonTheme: OutlinedButtonThemeData(
+      style: OutlinedButton.styleFrom(
+        foregroundColor: const Color(0xFF2F4858),
+        side: const BorderSide(color: Color(0xFFE7D7B1)),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+      ),
+    ),
+  );
+
+  runApp(const MyApp());
+}
+```
+
+---
+
 ## Related Flutter documentation
 
 - Material theming overview: https://docs.flutter.dev/cookbook/design/themes

--- a/payu_ui/THEME_CUSTOMIZATION.md
+++ b/payu_ui/THEME_CUSTOMIZATION.md
@@ -295,10 +295,9 @@ void main() {
 
 A very expressive style with a deep gradient base, extra-large rounded corners, strong shadows, vivid accents, custom typography, and bigger paddings.
 
-<img src="https://github.com/user-attachments/assets/5ecfb07f-fe25-4432-b3fd-c39b40b592f5" alt="Playful gradient / glassmorphism theme — screenshot 1" width="24%">
-<img src="https://github.com/user-attachments/assets/4fcabad8-d401-478d-98b0-5fee31945bbb" alt="Playful gradient / glassmorphism theme — screenshot 2" width="24%">
-<img src="https://github.com/user-attachments/assets/03d6cf0c-2ec1-4c37-af6b-7a1a1c23ca1e" alt="Playful gradient / glassmorphism theme — screenshot 3" width="24%">
-<img src="https://github.com/user-attachments/assets/7c4a3a95-2cc8-4958-836c-f888532e29bb" alt="Playful gradient / glassmorphism theme — screenshot 4" width="24%">
+<img src="https://github.com/user-attachments/assets/4fcabad8-d401-478d-98b0-5fee31945bbb" alt="Playful gradient / glassmorphism theme — screenshot 1" width="32%">
+<img src="https://github.com/user-attachments/assets/03d6cf0c-2ec1-4c37-af6b-7a1a1c23ca1e" alt="Playful gradient / glassmorphism theme — screenshot 2" width="32%">
+<img src="https://github.com/user-attachments/assets/7c4a3a95-2cc8-4958-836c-f888532e29bb" alt="Playful gradient / glassmorphism theme — screenshot 3" width="32%">
 
 ```dart
 void main() {

--- a/payu_ui/THEME_CUSTOMIZATION.md
+++ b/payu_ui/THEME_CUSTOMIZATION.md
@@ -368,6 +368,130 @@ void main() {
 
 ---
 
+### Example 3 — Playful gradient / glassmorphism
+
+A very expressive style with a deep gradient base, extra-large rounded corners, strong shadows, vivid accents, custom typography, and bigger paddings.
+
+```dart
+void main() {
+  Payu.theme = ThemeData(
+    useMaterial3: true,
+    fontFamily: 'SpaceGrotesk',
+    scaffoldBackgroundColor: const Color(0xFF120F2A),
+    colorScheme: const ColorScheme.dark(
+      primary: Color(0xFF7B61FF),
+      secondary: Color(0xFF21D4FD),
+      surface: Color(0xFF1B1738),
+      onSurface: Color(0xFFF4F2FF),
+      error: Color(0xFFFF5F7A),
+    ),
+    appBarTheme: AppBarTheme(
+      backgroundColor: const Color(0x991B1738),
+      foregroundColor: const Color(0xFFF4F2FF),
+      centerTitle: false,
+      elevation: 0,
+      scrolledUnderElevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(24),
+      ),
+      titleTextStyle: const TextStyle(
+        fontSize: 22,
+        fontWeight: FontWeight.w700,
+        letterSpacing: 0.2,
+      ),
+    ),
+    cardTheme: CardThemeData(
+      color: const Color(0xCC26214D),
+      margin: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+      elevation: 14,
+      shadowColor: const Color(0x8021D4FD),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(28),
+        side: const BorderSide(color: Color(0x66FFFFFF), width: 1.2),
+      ),
+    ),
+    dialogTheme: DialogThemeData(
+      backgroundColor: const Color(0xFF201A45),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(26),
+      ),
+    ),
+    inputDecorationTheme: InputDecorationTheme(
+      filled: true,
+      fillColor: const Color(0x662E275D),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 22, vertical: 20),
+      hintStyle: const TextStyle(color: Color(0xFFB9B3E3), fontSize: 15),
+      labelStyle: const TextStyle(
+        color: Color(0xFF21D4FD),
+        fontSize: 13,
+        fontWeight: FontWeight.w600,
+      ),
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(22),
+        borderSide: const BorderSide(color: Color(0x44FFFFFF)),
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(22),
+        borderSide: const BorderSide(color: Color(0x55FFFFFF)),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(22),
+        borderSide: const BorderSide(color: Color(0xFF21D4FD), width: 2.2),
+      ),
+      errorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(22),
+        borderSide: const BorderSide(color: Color(0xFFFF5F7A), width: 1.8),
+      ),
+    ),
+    textTheme: const TextTheme(
+      titleSmall: TextStyle(
+        fontSize: 17,
+        fontWeight: FontWeight.w700,
+        color: Color(0xFFF4F2FF),
+      ),
+      bodyMedium: TextStyle(
+        fontSize: 15,
+        height: 1.45,
+        color: Color(0xFFD0C9FF),
+      ),
+      bodySmall: TextStyle(
+        fontSize: 13,
+        fontWeight: FontWeight.w500,
+        letterSpacing: 0.1,
+        color: Color(0xFFB9B3E3),
+      ),
+    ),
+    elevatedButtonTheme: ElevatedButtonThemeData(
+      style: ElevatedButton.styleFrom(
+        backgroundColor: const Color(0xFF7B61FF),
+        foregroundColor: Colors.white,
+        elevation: 8,
+        shadowColor: const Color(0xFF7B61FF),
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+        textStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w700),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(20),
+        ),
+      ),
+    ),
+    outlinedButtonTheme: OutlinedButtonThemeData(
+      style: OutlinedButton.styleFrom(
+        foregroundColor: const Color(0xFF21D4FD),
+        side: const BorderSide(color: Color(0xFF21D4FD), width: 1.5),
+        padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 14),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(20),
+        ),
+      ),
+    ),
+  );
+
+  runApp(const MyApp());
+}
+```
+
+---
+
 ## Related Flutter documentation
 
 - Material theming overview: https://docs.flutter.dev/cookbook/design/themes

--- a/payu_ui/THEME_CUSTOMIZATION.md
+++ b/payu_ui/THEME_CUSTOMIZATION.md
@@ -1,8 +1,9 @@
 # PayU plugin theme customization
 
 This plugin uses a Material `ThemeData` object available as `Payu.theme`.
+Every PayU screen and widget is wrapped by an internal `Theme` widget that injects `Payu.theme`, so all visual customization flows through a single place.
 
-## How to provide custom theme
+## How to provide a custom theme
 
 ```dart
 void main() {
@@ -14,69 +15,12 @@ void main() {
 }
 ```
 
-- `Payu.theme` is applied inside PayU wrappers:
-  - `payu_state_management/lib/src/payu_widget.dart`
-  - `payu_ui/lib/src/widgets/payu_provider_widget.dart`
 - Setting `Payu.theme = null` restores the default PayU theme (`ThemeDataFactory.platform()`).
-
-## Default PayU theme definition
-
-The default theme is created in:
-- `payu_ui/lib/src/theme/theme_data_factory.dart`
-
-It defines:
-- `appBarTheme`
-- `cardTheme`
-- `dialogTheme`
-- `inputDecorationTheme`
-- `textTheme`
-- `colorScheme`
-- `primaryColor`
-
-## What can be overridden and where it is used
-
-### `appBarTheme`
-Used by pages with `AppBar(...)`:
-- `payu_add_card/lib/src/page/add_card_page.dart`
-- `payu_payment_methods/lib/src/features/payment_methods/payment_methods_page.dart`
-- `payu_payment_methods/lib/src/features/pbl_payment_methods/pbl_payment_methods_page.dart`
-- `payu_web_payments/lib/src/web_payments_page.dart`
-
-### `cardTheme`
-Used by `Card(...)` components:
-- `payu_payment_methods/lib/src/features/payment_methods/payment_methods_page.dart`
-- `payu_payment_methods/lib/src/features/pbl_payment_methods/pbl_payment_methods_page.dart`
-
-### `dialogTheme`
-Used by `AlertDialog(...)` components:
-- `payu_web_payments/lib/src/cvv/cvv_authorization_alert_dialog.dart`
-- `payu_three_ds/lib/src/soft_accept/soft_accept_alert_dialog.dart`
-- `payu_web_payments/lib/src/web_payments_page.dart` (dialogs opened in `showBackAlertDialog` and `showWebResourceErrorAlertDialog`)
-
-### `inputDecorationTheme`
-Used by `TextField(..., decoration: InputDecoration(...))`:
-- `payu_add_card/lib/src/widget/widgets/add_card_text_field.dart`
-- `payu_payment_methods/lib/src/features/widget/payment_widget.dart` (`_BlikCode`)
-- `payu_web_payments/lib/src/cvv/cvv_authorization_alert_dialog.dart`
-
-### `textTheme`
-Used with `Theme.of(context).textTheme...`:
-- `payu_add_card/lib/src/widget/add_card_widget.dart`
-- `payu_payment_methods/lib/src/features/widget/payment_widget.dart`
-- `payu_terms_and_conditions/lib/src/terms_and_conditions_widget.dart`
-
-### `colorScheme` and `primaryColor`
-Used for surface/background and accent colors:
-- `payu_add_card/lib/src/page/add_card_page.dart`
-- `payu_payment_methods/lib/src/features/widget/payment_widget.dart`
-- `payu_payment_methods/lib/src/features/payment_methods/payment_methods_page.dart`
-- `payu_payment_methods/lib/src/features/pbl_payment_methods/pbl_payment_methods_page.dart`
-- `payu_terms_and_conditions/lib/src/terms_and_conditions_widget.dart`
-- `payu_web_payments/lib/src/web_payments_page.dart`
+- The default theme is selected automatically based on the device brightness — light or dark.
 
 ## Recommended customization approach
 
-To keep PayU defaults and change only selected parts, start from current theme:
+To keep the PayU defaults and change only selected parts, start from the current theme:
 
 ```dart
 Payu.theme = Payu.theme.copyWith(
@@ -89,16 +33,167 @@ Payu.theme = Payu.theme.copyWith(
 );
 ```
 
+## PayU brand color palette
+
+The default theme uses the following PayU brand colors (light mode):
+
+| Token | Hex | Usage |
+|---|---|---|
+| `primary2` | `#438F29` (PayU green) | App bar icons and title, card border accent, `colorScheme.primary` |
+| `secondaryGray1` | `#3F3F3F` (dark gray) | Body text, titles |
+| `secondaryGray2` | `#777777` (medium gray) | Subtitles, hints, secondary text |
+| `secondaryGray3` | `#E3E4E2` (light gray) | Borders, dividers |
+| `secondaryGray4` | `#F7F7F7` (very light gray) | Page backgrounds, card fill, dialog fill |
+| `tertiary2` | `Colors.red` | Error borders, error text |
+
+> In **dark mode** the gray scale is inverted — `secondaryGray1` becomes the lightest color and
+> `secondaryGray4` the darkest — while `primary2` and `tertiary2` remain the same.
+
+## Theme areas and what can be overridden
+
+### `appBarTheme`
+
+Controls the appearance of the top navigation bar shown on full-page screens.
+
+**Default values:**
+
+| Property | Default | Description |
+|---|---|---|
+| `backgroundColor` | `#F7F7F7` | Background of the app bar |
+| `iconTheme.color` | `#438F29` (PayU green) | Color of the leading (back / close) icon |
+| `iconTheme.size` | `24` | Size of the leading icon |
+| `actionsIconTheme.color` | `#438F29` (PayU green) | Color of action icons on the right side |
+| `actionsIconTheme.size` | `24` | Size of action icons |
+| `titleTextStyle` | 18sp, `#438F29` | Style of the app bar title text |
+
+**Features using `appBarTheme`:**
+- Add Card — full-page card form with a back button
+- Payment Methods — list of available payment methods
+- Bank Transfer (PBL) — grid of bank logos
+- Web Payments — browser page for redirect payments
+
+---
+
+### `cardTheme`
+
+Controls the appearance of `Card` containers used to display individual payment method rows and bank logo tiles.
+
+**Default values:**
+
+| Property | Default | Description |
+|---|---|---|
+| `color` | `#F7F7F7` | Card fill color |
+| `elevation` | `0` | No drop shadow |
+| `shadowColor` | `null` | Shadow is disabled |
+| `margin` | `EdgeInsets.all(0)` | No outer spacing (spacing is handled by the parent list) |
+| `shape` border color | `#E3E4E2` | 1 px outline border |
+| `shape` border radius | `8 px` | Rounded corners |
+
+**Features using `cardTheme`:**
+- Payment Methods — each payment method row is a `Card`
+- Bank Transfer (PBL) — each bank logo tile is a `Card`
+
+---
+
+### `dialogTheme`
+
+Controls the appearance of overlay dialogs (`AlertDialog`).
+
+**Default values:**
+
+| Property | Default | Description |
+|---|---|---|
+| `backgroundColor` | `#F7F7F7` | Dialog background |
+
+**Features using `dialogTheme`:**
+- Web Payments — "Go back?" confirmation dialog and "Connection not secure" error dialog
+- CVV Authorization — dialog asking the user to enter a CVV code
+- 3D Secure — dialog showing the 3DS soft-accept flow
+
+---
+
+### `inputDecorationTheme`
+
+Controls the appearance of all text input fields (card number, expiry date, CVV, BLIK code).
+All borders use `OutlineInputBorder` with an 8 px corner radius.
+
+**Default values:**
+
+| Property | Default | Description |
+|---|---|---|
+| `floatingLabelBehavior` | `FloatingLabelBehavior.always` | Label always floats above the field |
+| `border` | 1 px `#E3E4E2` outline | Default border state |
+| `enabledBorder` | 1 px `#E3E4E2` outline | Border when the field is enabled and not focused |
+| `focusedBorder` | 1 px `#E3E4E2` outline | Border when the field has focus |
+| `errorBorder` | 1 px red outline | Border when validation fails |
+| `focusedErrorBorder` | 1 px red outline | Border when focused and invalid |
+| `disabledBorder` | 1 px `#F7F7F7` outline | Border when the field is disabled (nearly invisible) |
+| `labelStyle` | 12sp, `#3F3F3F` | Floating label text style |
+| `hintStyle` | 14sp, `#777777` | Placeholder text style |
+| `helperStyle` | 12sp, `#777777` | Helper text below the field |
+| `errorStyle` | 12sp, red | Error message text style |
+
+**Features using `inputDecorationTheme`:**
+- Add Card Widget — card number, expiry date, and CVV fields
+- Payment Methods Widget — BLIK code entry field
+- CVV Authorization — CVV re-entry dialog field
+
+---
+
+### `textTheme`
+
+Controls all text styles. PayU components use only the slots listed below.
+
+**Default values:**
+
+| Slot | Font size | Color | Used in feature |
+|---|---|---|---|
+| `titleSmall` | 14sp | `#777777` | Payment method name and "select payment method" placeholder in Payment Methods Widget |
+| `bodyMedium` | 14sp | `#777777` | Payment method description in Payment Methods Widget |
+| `bodySmall` | 14sp | `#777777` | "New card" label in Add Card Widget; Terms & Conditions text |
+
+The remaining slots (`titleLarge`, `titleMedium`, `bodyLarge`, `labelLarge`, `labelSmall`) are defined in the default theme but are not currently consumed by any PayU widget.
+
+**Features using `textTheme`:**
+- Add Card Widget — "New card" section header
+- Payment Methods Widget — payment method name and description
+- Terms & Conditions Widget — legal disclaimer text
+
+---
+
+### `colorScheme` and `primaryColor`
+
+**Default values:**
+
+| Property | Default | Description |
+|---|---|---|
+| `colorScheme.primary` | `#438F29` (PayU green) | Arrow icon color in Payment Methods Widget |
+| `colorScheme.surface` | `#F7F7F7` | Page and container background color |
+| `colorScheme.onSurface` | `#777777` | Default text color on surfaces |
+| `colorScheme.error` | red | Error indicator color |
+| `colorScheme.onPrimary` | white | Text/icon color on primary-colored backgrounds |
+| `primaryColor` | `#438F29` (PayU green) | Link text color in Terms & Conditions Widget |
+
+**Features using `colorScheme` / `primaryColor`:**
+- Add Card Page — page background (`colorScheme.surface`)
+- Payment Methods Page — page background
+- Bank Transfer (PBL) Page — page background
+- Payment Methods Widget — container background and arrow icon color
+- Terms & Conditions Widget — background and link text color
+- Web Payments Page — page background
+
+---
+
 ## Related Flutter documentation
 
 - Material theming overview: https://docs.flutter.dev/cookbook/design/themes
 - `ThemeData`: https://api.flutter.dev/flutter/material/ThemeData-class.html
 - `ColorScheme`: https://api.flutter.dev/flutter/material/ColorScheme-class.html
+- `AppBarTheme`: https://api.flutter.dev/flutter/material/AppBarTheme-class.html
 - `CardThemeData`: https://api.flutter.dev/flutter/material/CardThemeData-class.html
+- `DialogThemeData`: https://api.flutter.dev/flutter/material/DialogThemeData-class.html
 - `InputDecorationTheme`: https://api.flutter.dev/flutter/material/InputDecorationTheme-class.html
 - `TextTheme`: https://api.flutter.dev/flutter/material/TextTheme-class.html
-- `AppBarTheme`: https://api.flutter.dev/flutter/material/AppBarTheme-class.html
-- `DialogThemeData`: https://api.flutter.dev/flutter/material/DialogThemeData-class.html
 
 Input filtering (used by PayU text fields together with themed `InputDecoration`):
 - `FilteringTextInputFormatter`: https://api.flutter.dev/flutter/services/FilteringTextInputFormatter-class.html

--- a/payu_ui/THEME_CUSTOMIZATION.md
+++ b/payu_ui/THEME_CUSTOMIZATION.md
@@ -194,8 +194,10 @@ The examples below show two completely different looks to illustrate how far the
 
 A dark background with vibrant cyan and hot-pink accents, heavy elevation, and large rounded corners.
 
-<!-- TODO: add screenshot -->
-<!-- ![Bold dark / neon theme](docs/screenshots/theme_dark_neon.png) -->
+![Bold dark / neon theme — screenshot 1](https://github.com/user-attachments/assets/2a9b8304-86f8-446a-a1be-5a3006ace5c9)
+![Bold dark / neon theme — screenshot 2](https://github.com/user-attachments/assets/27334744-9c51-4fa2-9317-1d64e9ac33fa)
+![Bold dark / neon theme — screenshot 3](https://github.com/user-attachments/assets/253d53bb-d12f-43d9-919a-6148dab381c9)
+![Bold dark / neon theme — screenshot 4](https://github.com/user-attachments/assets/87cb704b-d8c6-4550-93d2-b203b3eafb87)
 
 ```dart
 void main() {
@@ -270,8 +272,9 @@ void main() {
 
 An off-white canvas with warm gold accents and deep navy secondary tones. Subtle borders, generous padding, and no elevation for a refined look.
 
-<!-- TODO: add screenshot -->
-<!-- ![Elegant light / premium theme](docs/screenshots/theme_light_premium.png) -->
+![Elegant light / premium theme — screenshot 1](https://github.com/user-attachments/assets/fa8051bc-08c4-4415-a41b-02758ec163ed)
+![Elegant light / premium theme — screenshot 2](https://github.com/user-attachments/assets/cfb9f79e-29df-4000-8649-18e626826153)
+![Elegant light / premium theme — screenshot 3](https://github.com/user-attachments/assets/1b8c437d-f6df-4166-a6c5-6ab5a3dddc78)
 
 ```dart
 void main() {

--- a/payu_ui/THEME_CUSTOMIZATION.md
+++ b/payu_ui/THEME_CUSTOMIZATION.md
@@ -194,10 +194,12 @@ The examples below show two completely different looks to illustrate how far the
 
 A dark background with vibrant cyan and hot-pink accents, heavy elevation, and large rounded corners.
 
-![Bold dark / neon theme — screenshot 1](https://github.com/user-attachments/assets/2a9b8304-86f8-446a-a1be-5a3006ace5c9)
-![Bold dark / neon theme — screenshot 2](https://github.com/user-attachments/assets/27334744-9c51-4fa2-9317-1d64e9ac33fa)
-![Bold dark / neon theme — screenshot 3](https://github.com/user-attachments/assets/253d53bb-d12f-43d9-919a-6148dab381c9)
-![Bold dark / neon theme — screenshot 4](https://github.com/user-attachments/assets/87cb704b-d8c6-4550-93d2-b203b3eafb87)
+<img src="https://github.com/user-attachments/assets/2a9b8304-86f8-446a-a1be-5a3006ace5c9" alt="Bold dark / neon theme — screenshot 1" width="32%">
+<img src="https://github.com/user-attachments/assets/27334744-9c51-4fa2-9317-1d64e9ac33fa" alt="Bold dark / neon theme — screenshot 2" width="32%">
+<img src="https://github.com/user-attachments/assets/253d53bb-d12f-43d9-919a-6148dab381c9" alt="Bold dark / neon theme — screenshot 3" width="32%">
+<br/>
+<img src="https://github.com/user-attachments/assets/87cb704b-d8c6-4550-93d2-b203b3eafb87" alt="Bold dark / neon theme — screenshot 4" width="32%">
+<img src="https://github.com/user-attachments/assets/e56a1ccd-0b30-4707-8f4e-7309023c7e3b" alt="Bold dark / neon theme — screenshot 5" width="32%">
 
 ```dart
 void main() {
@@ -272,9 +274,9 @@ void main() {
 
 An off-white canvas with warm gold accents and deep navy secondary tones. Subtle borders, generous padding, and no elevation for a refined look.
 
-![Elegant light / premium theme — screenshot 1](https://github.com/user-attachments/assets/fa8051bc-08c4-4415-a41b-02758ec163ed)
-![Elegant light / premium theme — screenshot 2](https://github.com/user-attachments/assets/cfb9f79e-29df-4000-8649-18e626826153)
-![Elegant light / premium theme — screenshot 3](https://github.com/user-attachments/assets/1b8c437d-f6df-4166-a6c5-6ab5a3dddc78)
+<img src="https://github.com/user-attachments/assets/fa8051bc-08c4-4415-a41b-02758ec163ed" alt="Elegant light / premium theme — screenshot 1" width="32%">
+<img src="https://github.com/user-attachments/assets/cfb9f79e-29df-4000-8649-18e626826153" alt="Elegant light / premium theme — screenshot 2" width="32%">
+<img src="https://github.com/user-attachments/assets/1b8c437d-f6df-4166-a6c5-6ab5a3dddc78" alt="Elegant light / premium theme — screenshot 3" width="32%">
 
 ```dart
 void main() {

--- a/payu_ui/THEME_CUSTOMIZATION.md
+++ b/payu_ui/THEME_CUSTOMIZATION.md
@@ -197,9 +197,6 @@ A dark background with vibrant cyan and hot-pink accents, heavy elevation, and l
 <img src="https://github.com/user-attachments/assets/2a9b8304-86f8-446a-a1be-5a3006ace5c9" alt="Bold dark / neon theme — screenshot 1" width="32%">
 <img src="https://github.com/user-attachments/assets/27334744-9c51-4fa2-9317-1d64e9ac33fa" alt="Bold dark / neon theme — screenshot 2" width="32%">
 <img src="https://github.com/user-attachments/assets/253d53bb-d12f-43d9-919a-6148dab381c9" alt="Bold dark / neon theme — screenshot 3" width="32%">
-<br/>
-<img src="https://github.com/user-attachments/assets/87cb704b-d8c6-4550-93d2-b203b3eafb87" alt="Bold dark / neon theme — screenshot 4" width="32%">
-<img src="https://github.com/user-attachments/assets/e56a1ccd-0b30-4707-8f4e-7309023c7e3b" alt="Bold dark / neon theme — screenshot 5" width="32%">
 
 ```dart
 void main() {

--- a/payu_ui/THEME_CUSTOMIZATION.md
+++ b/payu_ui/THEME_CUSTOMIZATION.md
@@ -190,84 +190,7 @@ The examples below show two completely different looks to illustrate how far the
 
 ---
 
-### Example 1 — Bold dark / neon
-
-A dark background with vibrant cyan and hot-pink accents, heavy elevation, and large rounded corners.
-
-<img src="https://github.com/user-attachments/assets/2a9b8304-86f8-446a-a1be-5a3006ace5c9" alt="Bold dark / neon theme — screenshot 1" width="32%">
-<img src="https://github.com/user-attachments/assets/27334744-9c51-4fa2-9317-1d64e9ac33fa" alt="Bold dark / neon theme — screenshot 2" width="32%">
-<img src="https://github.com/user-attachments/assets/253d53bb-d12f-43d9-919a-6148dab381c9" alt="Bold dark / neon theme — screenshot 3" width="32%">
-
-```dart
-void main() {
-  Payu.theme = ThemeData(
-    brightness: Brightness.dark,
-    colorScheme: const ColorScheme.dark(
-      primary: Color(0xFFFF2E63),
-      secondary: Color(0xFF08D9D6),
-      surface: Color(0xFF1A1A2E),
-      onSurface: Colors.white,
-      error: Color(0xFFFF6B6B),
-    ),
-    scaffoldBackgroundColor: const Color(0xFF0F0F1A),
-    appBarTheme: const AppBarTheme(
-      backgroundColor: Color(0xFF1A1A2E),
-      foregroundColor: Color(0xFFFF2E63),
-      centerTitle: true,
-      elevation: 0,
-    ),
-    cardTheme: CardThemeData(
-      color: const Color(0xFF22223B),
-      elevation: 6,
-      shadowColor: Colors.black54,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(20),
-        side: const BorderSide(color: Color(0xFF08D9D6), width: 1.5),
-      ),
-    ),
-    inputDecorationTheme: InputDecorationTheme(
-      filled: true,
-      fillColor: const Color(0xFF2A2A40),
-      hintStyle: const TextStyle(color: Colors.white70),
-      labelStyle: const TextStyle(color: Color(0xFF08D9D6)),
-      border: OutlineInputBorder(
-        borderRadius: BorderRadius.circular(16),
-      ),
-      enabledBorder: OutlineInputBorder(
-        borderRadius: BorderRadius.circular(16),
-        borderSide: const BorderSide(color: Color(0xFF08D9D6)),
-      ),
-      focusedBorder: OutlineInputBorder(
-        borderRadius: BorderRadius.circular(16),
-        borderSide: const BorderSide(color: Color(0xFFFF2E63), width: 2),
-      ),
-    ),
-    textTheme: const TextTheme(
-      bodyMedium: TextStyle(fontSize: 15, color: Colors.white),
-      titleSmall: TextStyle(
-        fontSize: 16,
-        fontWeight: FontWeight.bold,
-        color: Color(0xFFFF2E63),
-      ),
-    ),
-    elevatedButtonTheme: ElevatedButtonThemeData(
-      style: ElevatedButton.styleFrom(
-        backgroundColor: const Color(0xFFFF2E63),
-        foregroundColor: Colors.white,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(14),
-        ),
-      ),
-    ),
-  );
-
-  runApp(const MyApp());
-}
-```
-
----
-
-### Example 2 — Elegant light / premium
+### Example 1 — Elegant light / premium
 
 An off-white canvas with warm gold accents and deep navy secondary tones. Subtle borders, generous padding, and no elevation for a refined look.
 
@@ -368,9 +291,14 @@ void main() {
 
 ---
 
-### Example 3 — Playful gradient / glassmorphism
+### Example 2 — Playful gradient / glassmorphism
 
 A very expressive style with a deep gradient base, extra-large rounded corners, strong shadows, vivid accents, custom typography, and bigger paddings.
+
+<img src="https://github.com/user-attachments/assets/5ecfb07f-fe25-4432-b3fd-c39b40b592f5" alt="Playful gradient / glassmorphism theme — screenshot 1" width="24%">
+<img src="https://github.com/user-attachments/assets/4fcabad8-d401-478d-98b0-5fee31945bbb" alt="Playful gradient / glassmorphism theme — screenshot 2" width="24%">
+<img src="https://github.com/user-attachments/assets/03d6cf0c-2ec1-4c37-af6b-7a1a1c23ca1e" alt="Playful gradient / glassmorphism theme — screenshot 3" width="24%">
+<img src="https://github.com/user-attachments/assets/7c4a3a95-2cc8-4958-836c-f888532e29bb" alt="Playful gradient / glassmorphism theme — screenshot 4" width="24%">
 
 ```dart
 void main() {

--- a/payu_ui/THEME_CUSTOMIZATION.md
+++ b/payu_ui/THEME_CUSTOMIZATION.md
@@ -1,0 +1,102 @@
+# PayU plugin theme customization
+
+This plugin uses a Material `ThemeData` object available as `Payu.theme`.
+
+## How to provide custom theme
+
+```dart
+void main() {
+  Payu.theme = ThemeData(
+    // your custom Material theme here
+  );
+
+  runApp(const MyApp());
+}
+```
+
+- `Payu.theme` is applied inside PayU wrappers:
+  - `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_state_management/lib/src/payu_widget.dart`
+  - `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_ui/lib/src/widgets/payu_provider_widget.dart`
+- Setting `Payu.theme = null` restores the default PayU theme (`ThemeDataFactory.platform()`).
+
+## Default PayU theme definition
+
+The default theme is created in:
+- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_ui/lib/src/theme/theme_data_factory.dart`
+
+It defines:
+- `appBarTheme`
+- `cardTheme`
+- `dialogTheme`
+- `inputDecorationTheme`
+- `textTheme`
+- `colorScheme`
+- `primaryColor`
+
+## What can be overridden and where it is used
+
+### `appBarTheme`
+Used by pages with `AppBar(...)`:
+- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_add_card/lib/src/page/add_card_page.dart`
+- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_payment_methods/lib/src/features/payment_methods/payment_methods_page.dart`
+- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_payment_methods/lib/src/features/pbl_payment_methods/pbl_payment_methods_page.dart`
+- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_web_payments/lib/src/web_payments_page.dart`
+
+### `cardTheme`
+Used by `Card(...)` components:
+- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_payment_methods/lib/src/features/payment_methods/payment_methods_page.dart`
+- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_payment_methods/lib/src/features/pbl_payment_methods/pbl_payment_methods_page.dart`
+
+### `dialogTheme`
+Used by `AlertDialog(...)` components:
+- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_web_payments/lib/src/cvv/cvv_authorization_alert_dialog.dart`
+- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_three_ds/lib/src/soft_accept/soft_accept_alert_dialog.dart`
+- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_web_payments/lib/src/web_payments_page.dart` (dialogs opened in `showBackAlertDialog` and `showWebResourceErrorAlertDialog`)
+
+### `inputDecorationTheme`
+Used by `TextField(..., decoration: InputDecoration(...))`:
+- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_add_card/lib/src/widget/widgets/add_card_text_field.dart`
+- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_payment_methods/lib/src/features/widget/payment_widget.dart` (`_BlikCode`)
+- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_web_payments/lib/src/cvv/cvv_authorization_alert_dialog.dart`
+
+### `textTheme`
+Used with `Theme.of(context).textTheme...`:
+- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_add_card/lib/src/widget/add_card_widget.dart`
+- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_payment_methods/lib/src/features/widget/payment_widget.dart`
+- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_terms_and_conditions/lib/src/terms_and_conditions_widget.dart`
+
+### `colorScheme` and `primaryColor`
+Used for surface/background and accent colors:
+- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_add_card/lib/src/page/add_card_page.dart`
+- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_payment_methods/lib/src/features/widget/payment_widget.dart`
+- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_payment_methods/lib/src/features/payment_methods/payment_methods_page.dart`
+- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_payment_methods/lib/src/features/pbl_payment_methods/pbl_payment_methods_page.dart`
+- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_terms_and_conditions/lib/src/terms_and_conditions_widget.dart`
+- `/tmp/workspace/PayU-EMEA/PayU-Flutter/payu_web_payments/lib/src/web_payments_page.dart`
+
+## Recommended customization approach
+
+To keep PayU defaults and change only selected parts, start from current theme:
+
+```dart
+Payu.theme = Payu.theme.copyWith(
+  cardTheme: Payu.theme.cardTheme.copyWith(
+    color: Colors.white,
+  ),
+  inputDecorationTheme: Payu.theme.inputDecorationTheme.copyWith(
+    floatingLabelBehavior: FloatingLabelBehavior.auto,
+  ),
+);
+```
+
+## Related Flutter documentation
+
+- Material theming overview: https://docs.flutter.dev/cookbook/design/themes
+- `ThemeData`: https://api.flutter.dev/flutter/material/ThemeData-class.html
+- `ColorScheme`: https://api.flutter.dev/flutter/material/ColorScheme-class.html
+- `CardThemeData`: https://api.flutter.dev/flutter/material/CardThemeData-class.html
+- `InputDecorationTheme`: https://api.flutter.dev/flutter/material/InputDecorationTheme-class.html
+- `TextTheme`: https://api.flutter.dev/flutter/material/TextTheme-class.html
+- `AppBarTheme`: https://api.flutter.dev/flutter/material/AppBarTheme-class.html
+- `DialogThemeData`: https://api.flutter.dev/flutter/material/DialogThemeData-class.html
+- `FilteringTextInputFormatter`: https://api.flutter.dev/flutter/services/FilteringTextInputFormatter-class.html


### PR DESCRIPTION
The documentation had two issues: Example 2 in the theme customization guide showed a duplicated first image, and the main README customization section was too verbose. This update removes the duplicate screenshot and keeps README guidance short while preserving the link to full customization docs.

- **Theme customization doc cleanup**
  - Removed duplicated first screenshot from **Example 2 — Playful gradient / glassmorphism** in `payu_ui/THEME_CUSTOMIZATION.md`.
  - Kept image ordering/labels consistent after removal.

- **README customization section simplification**
  - Reduced the new `## UI Customization` section in `README.md` to a compact summary.
  - Removed the inline code example and long bullet list.
  - Kept direct link to `payu_ui/THEME_CUSTOMIZATION.md` for full details.

```md
## UI Customization

Customize PayU UI with `Payu.theme` (`ThemeData`) to control colors, typography, inputs, cards, and buttons across all PayU screens.

For full details and examples, see the [Theme Customization guide](payu_ui/THEME_CUSTOMIZATION.md).
```